### PR TITLE
Extracting device XID using libinput_device_get_sysname

### DIFF
--- a/src/io/input.cpp
+++ b/src/io/input.cpp
@@ -102,11 +102,10 @@ void gebaar::io::Input::update_device_list(){
 
 void gebaar::io::Input::determine_orientation(libinput_device* dev) {
   Display * display = XOpenDisplay(NULL);
-  int vendor = libinput_device_get_id_vendor(dev);
-  int product = libinput_device_get_id_product(dev);
-  int id = deviceids[vendor][product];
-  spdlog::get("main")->debug("[{}] at {} - {}: idmap {}.{}.{}",
-                                 FN, __LINE__, __func__, vendor, product, id);
+  const char* sysname = libinput_device_get_sysname(dev);
+  int id = atoi(sysname+5);
+  spdlog::get("main")->debug("[{}] at {} - {}: idmap {}",
+                                 FN, __LINE__, __func__, id);
   Atom floatAtom;
   Atom type_return;
   floatAtom = XInternAtom(display, "FLOAT", false);


### PR DESCRIPTION
We can't uniquely map vendor ID and product ID to an XID for our input device. This leads to possible confusion when mapping a vendor ID and product ID to an XID, particularly for touchscreen devices (See the section on `libinput_device_get_device_group()` at [Initialization and manipulation of input devices](https://wayland.freedesktop.org/libinput/doc/latest/api/group__device.html)). This pull request attempts to get the XID directly from the libinput device object using `libinput_device_get_sysname`.

**Background**

There is a 1:1 mapping between libinput devices and `/dev/input/eventX` device nodes. ([Source](https://wayland.freedesktop.org/libinput/doc/latest/architecture.html))

Based on the code in the libinput-tools [here](https://github.com/wayland-project/libinput/blob/master/tools/libinput-debug-events.c), it looks like `libinput_device_get_sysname` returns `eventX`

**Note:** The `X` in `/dev/input/eventX` represents is here called the XID . This appears to be consistent with the use of the name XID in the [xinput documentation](https://www.x.org/archive/current/doc/man/man1/xinput.1.xhtml).