### PR TITLE
adding -Wno-c++20-compat flag to CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.10.2)
 project(gebaar)
 set(CMAKE_EXPORT_COMPILE_COMMANDS on)
 set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -Wall -Wextra -Werror -pedantic -pthread")
+set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -Wall -Wextra -Werror -Wno-c++20-compat -pedantic -pthread")
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/")
 
 find_package(Libinput REQUIRED)


### PR DESCRIPTION
(on Kubuntu 23.10) compilation fails at the `make -j$(nproc)` step with a bunch of warnings 

```
error: identifier ‘char8_t’ is a keyword in C++20 [-Werror=c++20-compat]
  369 | enum char8_t : unsigned char {};
      |      ^~~~~~~
```

Adding the -Wno-c++20-compat flag resolves it & lets it compile. Note this is only after the changes to cpptoml and cxxopts files with `#include <limits>` as you said in #17 , so that will have to be addressed too for it to compile out of the box, but I found even after doing that the compatibility thing prevented me from building.